### PR TITLE
Add drag-and-drop PDF ordering

### DIFF
--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -4,11 +4,17 @@
 
 <h2>Merge PDF Files</h2>
 
-<form asp-action="Merge" method="post" enctype="multipart/form-data">
-    <input type="file" name="files" multiple />
+<form id="mergeForm" asp-action="Merge" method="post" enctype="multipart/form-data">
+    <input type="file" id="fileInput" multiple />
+    <p>Select files and drag to reorder them:</p>
+    <ul id="fileList"></ul>
     <button type="submit">Merge</button>
 </form>
-@if(ViewBag.Message != null)
+@if (ViewBag.Message != null)
 {
     <p>@ViewBag.Message</p>
+}
+
+@section Scripts {
+    <script src="~/js/merge.js"></script>
 }

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -9,5 +9,6 @@
     <div class="container">
         @RenderBody()
     </div>
+    @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -4,3 +4,26 @@ body {
 .container {
     margin: 20px;
 }
+
+#fileList {
+    list-style: none;
+    padding: 0;
+    margin-top: 10px;
+}
+
+#fileList li {
+    padding: 8px 12px;
+    margin-bottom: 4px;
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    cursor: move;
+}
+
+input[type="file"] {
+    margin-bottom: 10px;
+}
+
+button {
+    padding: 6px 12px;
+    cursor: pointer;
+}

--- a/wwwroot/js/merge.js
+++ b/wwwroot/js/merge.js
@@ -1,0 +1,75 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const fileInput = document.getElementById('fileInput');
+    const fileList = document.getElementById('fileList');
+    const form = document.getElementById('mergeForm');
+    const files = [];
+
+    fileInput.addEventListener('change', (e) => {
+        for (const file of e.target.files) {
+            files.push(file);
+        }
+        renderList();
+        fileInput.value = '';
+    });
+
+    function renderList() {
+        fileList.innerHTML = '';
+        files.forEach((file, index) => {
+            const li = document.createElement('li');
+            li.textContent = file.name;
+            li.draggable = true;
+            li.dataset.index = index;
+            li.addEventListener('dragstart', handleDragStart);
+            li.addEventListener('dragover', handleDragOver);
+            li.addEventListener('drop', handleDrop);
+            fileList.appendChild(li);
+        });
+    }
+
+    let dragSrcIndex = null;
+
+    function handleDragStart(e) {
+        dragSrcIndex = +this.dataset.index;
+        e.dataTransfer.effectAllowed = 'move';
+    }
+
+    function handleDragOver(e) {
+        e.preventDefault();
+    }
+
+    function handleDrop(e) {
+        e.preventDefault();
+        const destIndex = +this.dataset.index;
+        if (dragSrcIndex === null || destIndex === undefined) return;
+        const [moved] = files.splice(dragSrcIndex, 1);
+        files.splice(destIndex, 0, moved);
+        renderList();
+    }
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (files.length === 0) {
+            alert('Please select files');
+            return;
+        }
+        const formData = new FormData();
+        files.forEach(file => formData.append('files', file));
+        const response = await fetch(form.action, {
+            method: 'POST',
+            body: formData
+        });
+        if (!response.ok) {
+            alert('Error merging PDF');
+            return;
+        }
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'merged.pdf';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+    });
+});


### PR DESCRIPTION
## Summary
- Allow users to reorder uploaded PDFs via drag and drop before merging
- Style merge page and PDF list for clearer interaction
- Expose script section in layout to load new JavaScript

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c18e7b0832abf30d1bbf57a2134