### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+.git
+.gitignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# build stage
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+# runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+WORKDIR /app
+COPY --from=build /app ./
+ENV ASPNETCORE_URLS=http://0.0.0.0:${PORT}
+ENTRYPOINT ["dotnet", "MergePDF.dll"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# MergePDF
+
+Simple ASP.NET Core application to merge multiple PDF files into one. Provides a web form for uploading PDFs and returns a merged document.
+
+## Prerequisites
+- [.NET 7 SDK](https://dotnet.microsoft.com/en-us/download)
+- [Docker](https://www.docker.com/) (optional, for containerization)
+
+## Local Development
+```bash
+dotnet build
+dotnet run
+```
+The application will listen on `http://localhost:5000` by default.
+
+## Docker
+Build and run the container:
+```bash
+docker build -t mergepdf .
+docker run -p 8080:8080 mergepdf
+```
+The service will be accessible at `http://localhost:8080`.
+
+## Deploy to Google Cloud Run
+1. Build and push the container image:
+   ```bash
+   gcloud builds submit --tag gcr.io/PROJECT_ID/mergepdf
+   ```
+2. Deploy:
+   ```bash
+   gcloud run deploy mergepdf \
+       --image gcr.io/PROJECT_ID/mergepdf \
+       --platform managed \
+       --region REGION \
+       --allow-unauthenticated
+   ```
+Replace `PROJECT_ID` and `REGION` with your Google Cloud project ID and desired region.


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running MergePDF in a container
- ignore build artifacts with .dockerignore
- document local and Cloud Run deployment in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d90a13250832abb32645528de338d